### PR TITLE
Add macOS packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ To run locally:
    streamlit run encounter_sim.py
    ```
 
+## Building a macOS Application
+
+You can create a standalone macOS binary using PyInstaller. This bundles the
+simulator and all of its dependencies so it can be launched like any other Mac
+application.
+
+1. Ensure Python 3.12 is installed on your Mac.
+2. Install the required packages for packaging:
+   ```bash
+   pip install -r requirements.txt
+   pip install pyinstaller
+   ```
+3. Run the build script:
+   ```bash
+   ./build_mac.sh
+   ```
+4. The resulting application will be located in the `dist/` folder.
+
+
 ## Contributing
 
 Feel free to open issues or submit pull requests with improvements or bug fixes.

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Script to build a standalone macOS application using PyInstaller
+# Usage: ./build_mac.sh
+set -e
+
+# Ensure PyInstaller is available
+pip install --upgrade pyinstaller
+
+pyinstaller \
+    --onefile \
+    --windowed \
+    --name WearyCombatSim \
+    encounter_sim.py
+
+# Output will be in the dist/ directory


### PR DESCRIPTION
## Summary
- add `build_mac.sh` for creating a macOS binary with PyInstaller
- document how to build the macOS app in README

## Testing
- `python -m py_compile encounter_sim.py`
- `./build_mac.sh` *(fails: Could not find a version that satisfies the requirement pyinstaller)*

------
https://chatgpt.com/codex/tasks/task_e_683faa7966cc832d92f38a825d5684a9